### PR TITLE
Initialize Reader SDK at application level

### DIFF
--- a/doc/get-started.md
+++ b/doc/get-started.md
@@ -115,19 +115,40 @@ For more information on installing Reader SDK for Android, see the
       ...
     }
     ```
-1. Extend the Android Application class (`android.app.Application`) and add code
-   to Import and initialize Reader SDK:
-    ```java
-    import com.squareup.sdk.reader.ReaderSdk;
+1. Open or create `MainApplication` class in your project, make sure extend the Flutter Application class (`FlutterApplication`) and add code
+   to import and initialize Reader SDK:
 
-    public class MainActivity extends FlutterActivity {
-        @Override
-        protected void onCreate(Bundle savedInstanceState) {
-            super.onCreate(savedInstanceState);
-            GeneratedPluginRegistrant.registerWith(this);
-            ReaderSdk.initialize(this.getApplication());
-        }
+    >`MainApplication` is not created by default through `flutter create <Project>`
+
+    ```java
+    package com.example.flutter.squareup.sdk.reader;
+
+    import com.squareup.sdk.reader.ReaderSdk;
+    import io.flutter.app.FlutterApplication;
+    import io.flutter.plugin.common.PluginRegistry;
+    import io.flutter.plugins.GeneratedPluginRegistrant;
+
+    public class MainApplication extends FlutterApplication implements PluginRegistry.PluginRegistrantCallback {
+      @Override
+      public void onCreate() {
+        super.onCreate();
+        ReaderSdk.initialize(this);
+      }
+
+      @Override
+      public void registerWith(PluginRegistry registry) {
+        GeneratedPluginRegistrant.registerWith(registry);
+      }
     }
+    ```
+
+1. If you create `MainApplication` class in above step, update `AndroidManifest.xml` in your project:
+    ```xml
+      <application
+        <!-- use custom "MainApplication" class instead of "io.flutter.app.FlutterApplication" -->
+        android:name=".MainApplication" 
+        ... />
+      </application>
     ```
 
 

--- a/doc/get-started.md
+++ b/doc/get-started.md
@@ -115,10 +115,10 @@ For more information on installing Reader SDK for Android, see the
       ...
     }
     ```
-1. Open or create `MainApplication` class in your project, make sure extend the Flutter Application class (`FlutterApplication`) and add code
-   to import and initialize Reader SDK:
-
-    >`MainApplication` is not created by default through `flutter create <Project>`
+1. Open the `MainApplication` class for your project. **Note that `MainApplication`
+is not created by default through `flutter create <Project>`, so you may need to
+create it**. Add code to extend the Flutter Application class
+(`FlutterApplication`) that imports and initializes Reader SDK:
 
     ```java
     package com.example.flutter.squareup.sdk.reader;

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -15,7 +15,7 @@
          additional functionality it is fine to subclass or reimplement
          FlutterApplication and put your custom class here. -->
     <application
-        android:name="io.flutter.app.FlutterApplication"
+        android:name=".MainApplication"
         android:label="square_reader_sdk_example"
         android:icon="@mipmap/ic_launcher">
         <activity

--- a/example/android/app/src/main/java/com/example/flutter/squareup/sdk/reader/MainApplication.java
+++ b/example/android/app/src/main/java/com/example/flutter/squareup/sdk/reader/MainApplication.java
@@ -15,15 +15,20 @@ limitations under the License.
 */
 package com.example.flutter.squareup.sdk.reader;
 
-import android.os.Bundle;
 import com.squareup.sdk.reader.ReaderSdk;
-import io.flutter.app.FlutterActivity;
+import io.flutter.app.FlutterApplication;
+import io.flutter.plugin.common.PluginRegistry;
 import io.flutter.plugins.GeneratedPluginRegistrant;
 
-public class MainActivity extends FlutterActivity {
+public class MainApplication extends FlutterApplication implements PluginRegistry.PluginRegistrantCallback {
   @Override
-  protected void onCreate(Bundle savedInstanceState) {
-    super.onCreate(savedInstanceState);
-    GeneratedPluginRegistrant.registerWith(this);
+  public void onCreate() {
+    super.onCreate();
+    ReaderSdk.initialize(this);
+  }
+
+  @Override
+  public void registerWith(PluginRegistry registry) {
+    GeneratedPluginRegistrant.registerWith(registry);
   }
 }


### PR DESCRIPTION
fix #22 

This avoid ReaderSDK.initialize is called twice in some scenario.