### PR TITLE
Add FOREGROUND_SERVICE permission to Android sample

### DIFF
--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -7,7 +7,7 @@
     -->
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.CAMERA" />
-
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
 
     <!-- io.flutter.app.FlutterApplication is an android.app.Application that
          calls FlutterMain.startInitialization(this); in its onCreate method.


### PR DESCRIPTION
The Android sample app crashes at the end of the transaction because it's missing android.permission.FOREGROUND_SERVICE. Adding it to AndroidManifest.xml should resolve the issue.