### PR TITLE
 Add FOREGROUND_SERVICE permission to Android sample

### DIFF
--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -7,6 +7,7 @@
     -->
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.CAMERA" />
+    <!-- The FOREGROUND_SERVICE permission is required for API level 28 and greater. -->
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
 
 

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -7,6 +7,7 @@
     -->
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.CAMERA" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
 
 
     <!-- io.flutter.app.FlutterApplication is an android.app.Application that


### PR DESCRIPTION
The Android sample app crashes at the end of the transaction because it's missing android.permission.FOREGROUND_SERVICE. Adding it to AndroidManifest.xml should resolve the issue.

This is occurring on an emulated x86 API 28 device.