### PR TITLE
Fix the broken Android default Reader SDK setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### v2.0.1 Mar 29, 2019
+
+* Fix the bug on Android default Reader SDK version setting
+
 ### v2.0.0 Mar 29, 2019
 
 * Support AnroidX.

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -44,7 +44,7 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 def DEFAULT_PLAY_SERVICES_BASE_VERSION = '12.0.1'
-def READER_SDK_VERSION = '[1.2.1 2.0)'
+def READER_SDK_VERSION = '[1.2.1, 2.0)'
 
 android {
     compileSdkVersion 28

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: square_reader_sdk
 description: An open source Flutter plugin for calling Square’s native Reader SDK implementations to take in-person payments on iOS and Android.
-version: 2.0.0
+version: 2.0.1
 author: Square Flutter Team <flutter-team@squareup.com>
 homepage: https://github.com/square/reader-sdk-flutter-plugin
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

We can only accept your change after you sign this Individual Contributor License Agreement (CLA), you'll get the CLA link after create PR.

Learn more about the contributing rules from https://github.com/square/reader-sdk-flutter-plugin/blob/master/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
The Android Reader SDK version setting is wrong and broken. This is a fix for this issue.

## Related issues

N/A

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/square/reader-sdk-flutter-plugin/blob/master/CHANGELOG.md for an example. -->

* Fix the bug on Android default Reader SDK version setting

## Test Plan

<!-- Demonstrate the code is solid. Example: Manually test the quick start example works. -->
Manually verified the update is correct and fixed the problem.