### PR TITLE
Added support for Flutter 1.12+, updated the example to use v2 flutte…

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ In addition to this README, the following is available in the
 
 ## Build requirements
 
+### Flutter
+
+A version of Flutter greater than 1.12 is required for v2 embedding support. Any application that uses v1 embeddings for android will still be backwards compatible and supported.
+  
 ### Android
 
 * minSdkVersion is API 21 (Lollipop 5.0) or higher.

--- a/android/src/main/java/com/squareup/sdk/reader/flutter/CheckoutModule.java
+++ b/android/src/main/java/com/squareup/sdk/reader/flutter/CheckoutModule.java
@@ -16,6 +16,8 @@ limitations under the License.
 package com.squareup.sdk.reader.flutter;
 
 import android.app.Activity;
+import android.content.Context;
+
 import com.squareup.sdk.reader.ReaderSdk;
 import com.squareup.sdk.reader.checkout.AdditionalPaymentType;
 import com.squareup.sdk.reader.checkout.CheckoutActivityCallback;
@@ -48,13 +50,13 @@ final class CheckoutModule {
   private static final String FL_MESSAGE_CHECKOUT_ALREADY_IN_PROGRESS = "A checkout operation is already in progress. Ensure that the in-progress checkout is completed before calling startCheckoutAsync again.";
   private static final String FL_MESSAGE_CHECKOUT_INVALID_PARAMETER = "Invalid parameter found in checkout parameters.";
 
-  private final Activity currentActivity;
+  private Context currentContext;
   private final CheckoutResultConverter checkoutResultConverter;
   private volatile CallbackReference checkoutCallbackRef;
 
 
-  public CheckoutModule(Activity activity) {
-    currentActivity = activity;
+  public CheckoutModule(Context context) {
+    currentContext = context;
     checkoutResultConverter = new CheckoutResultConverter();
   }
 
@@ -125,7 +127,11 @@ final class CheckoutModule {
     }
 
     final CheckoutParameters checkoutParams = checkoutParamsBuilder.build();
-    ReaderSdk.checkoutManager().startCheckoutActivity(currentActivity, checkoutParams);
+    ReaderSdk.checkoutManager().startCheckoutActivity(currentContext, checkoutParams);
+  }
+
+  public void setContext(Context context) {
+    this.currentContext = context;
   }
 
   static private boolean validateCheckoutParams(HashMap<String, Object> checkoutParamsMap, StringBuilder paramError) {

--- a/android/src/main/java/com/squareup/sdk/reader/flutter/ReaderSettingsModule.java
+++ b/android/src/main/java/com/squareup/sdk/reader/flutter/ReaderSettingsModule.java
@@ -16,6 +16,8 @@ limitations under the License.
 package com.squareup.sdk.reader.flutter;
 
 import android.app.Activity;
+import android.content.Context;
+
 import com.squareup.sdk.reader.ReaderSdk;
 import com.squareup.sdk.reader.core.CallbackReference;
 import com.squareup.sdk.reader.core.ResultError;
@@ -36,10 +38,10 @@ final class ReaderSettingsModule {
   private static final String FL_MESSAGE_READER_SETTINGS_ALREADY_IN_PROGRESS = "A reader settings operation is already in progress. Ensure that the in-progress reader settings is completed before calling startReaderSettingsAsync again.";
 
   private volatile CallbackReference readerSettingCallbackRef;
-  private final Activity currentActivity;
+  private Context currentContext;
 
-  public ReaderSettingsModule(Activity activity) {
-    currentActivity = activity;
+  public ReaderSettingsModule(Context context) {
+    currentContext = context;
   }
 
   public void startReaderSettings(final Result flutterResult) {
@@ -69,6 +71,10 @@ final class ReaderSettingsModule {
     readerSettingCallbackRef = ReaderSdk.readerManager()
         .addReaderSettingsActivityCallback(readerSettingsCallback);
 
-    ReaderSdk.readerManager().startReaderSettingsActivity(currentActivity);
+    ReaderSdk.readerManager().startReaderSettingsActivity(currentContext);
+  }
+
+  public void setContext(Context context) {
+    this.currentContext = context;
   }
 }

--- a/android/src/main/java/com/squareup/sdk/reader/flutter/SquareReaderSdkFlutterPlugin.java
+++ b/android/src/main/java/com/squareup/sdk/reader/flutter/SquareReaderSdkFlutterPlugin.java
@@ -38,7 +38,7 @@ public class SquareReaderSdkFlutterPlugin implements MethodCallHandler, FlutterP
     methodChannel.setMethodCallHandler(instance);
   }
 
-  private MethodChannel methodChannel;
+  private static MethodChannel methodChannel;
   private AuthorizeModule authorizeModule;
   private CheckoutModule checkoutModule;
   private ReaderSettingsModule readerSettingsModule;

--- a/android/src/main/java/com/squareup/sdk/reader/flutter/SquareReaderSdkFlutterPlugin.java
+++ b/android/src/main/java/com/squareup/sdk/reader/flutter/SquareReaderSdkFlutterPlugin.java
@@ -35,6 +35,7 @@ public class SquareReaderSdkFlutterPlugin implements MethodCallHandler, FlutterP
   public static void registerWith(Registrar registrar) {
     SquareReaderSdkFlutterPlugin instance = new SquareReaderSdkFlutterPlugin(registrar.activity());
     instance.onAttachedToEngine(registrar.activity(), registrar.messenger());
+    methodChannel.setMethodCallHandler(instance);
   }
 
   private MethodChannel methodChannel;
@@ -98,12 +99,12 @@ public class SquareReaderSdkFlutterPlugin implements MethodCallHandler, FlutterP
   @Override
   public void onAttachedToEngine(@NonNull FlutterPluginBinding flutterPluginBinding) {
     onAttachedToEngine(flutterPluginBinding.getApplicationContext(), flutterPluginBinding.getBinaryMessenger());
+    methodChannel.setMethodCallHandler(this);
   }
 
   private void onAttachedToEngine(Context context, BinaryMessenger messenger) {
     methodChannel = new MethodChannel(messenger, "square_reader_sdk");
     init(context);
-    methodChannel.setMethodCallHandler(this);
   }
 
 

--- a/android/src/main/java/com/squareup/sdk/reader/flutter/SquareReaderSdkFlutterPlugin.java
+++ b/android/src/main/java/com/squareup/sdk/reader/flutter/SquareReaderSdkFlutterPlugin.java
@@ -15,8 +15,14 @@ limitations under the License.
 */
 package com.squareup.sdk.reader.flutter;
 
-import android.app.Activity;
-import com.squareup.sdk.reader.crm.StoreCustomerCardErrorCode;
+import android.content.Context;
+
+import androidx.annotation.NonNull;
+
+import io.flutter.embedding.engine.plugins.FlutterPlugin;
+import io.flutter.embedding.engine.plugins.activity.ActivityAware;
+import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding;
+import io.flutter.plugin.common.BinaryMessenger;
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
@@ -24,22 +30,40 @@ import io.flutter.plugin.common.MethodChannel.Result;
 import io.flutter.plugin.common.PluginRegistry.Registrar;
 import java.util.HashMap;
 
-public class SquareReaderSdkFlutterPlugin implements MethodCallHandler {
+public class SquareReaderSdkFlutterPlugin implements MethodCallHandler, FlutterPlugin, ActivityAware {
+
   public static void registerWith(Registrar registrar) {
-    final MethodChannel channel = new MethodChannel(registrar.messenger(), "square_reader_sdk");
-    channel.setMethodCallHandler(new SquareReaderSdkFlutterPlugin(registrar.activity()));
+    SquareReaderSdkFlutterPlugin instance = new SquareReaderSdkFlutterPlugin(registrar.activity());
+    instance.onAttachedToEngine(registrar.activity(), registrar.messenger());
   }
 
-  private final AuthorizeModule authorizeModule;
-  private final CheckoutModule checkoutModule;
-  private final ReaderSettingsModule readerSettingsModule;
-  private final StoreCustomerCardModule storeCustomerCardModule;
+  private MethodChannel methodChannel;
+  private AuthorizeModule authorizeModule;
+  private CheckoutModule checkoutModule;
+  private ReaderSettingsModule readerSettingsModule;
+  private StoreCustomerCardModule storeCustomerCardModule;
 
-  private SquareReaderSdkFlutterPlugin(Activity activity) {
+  private SquareReaderSdkFlutterPlugin(Context context) {
+    init(context);
+  }
+
+  /**
+   * Needed by GeneratedPluginRegistrant to be able to construct the plugin and call onAttachedToEngine.
+   */
+  public SquareReaderSdkFlutterPlugin() {
+  }
+
+  private void init(Context context) {
     authorizeModule = new AuthorizeModule();
-    checkoutModule = new CheckoutModule(activity);
-    readerSettingsModule = new ReaderSettingsModule(activity);
-    storeCustomerCardModule = new StoreCustomerCardModule(activity);
+    checkoutModule = new CheckoutModule(context);
+    readerSettingsModule = new ReaderSettingsModule(context);
+    storeCustomerCardModule = new StoreCustomerCardModule(context);
+  }
+
+  private void setContextForModules(final Context context) {
+    checkoutModule.setContext(context);
+    readerSettingsModule.setContext(context);
+    storeCustomerCardModule.setContext(context);
   }
 
   @Override
@@ -69,5 +93,41 @@ public class SquareReaderSdkFlutterPlugin implements MethodCallHandler {
     } else {
       result.notImplemented();
     }
+  }
+
+  @Override
+  public void onAttachedToEngine(@NonNull FlutterPluginBinding flutterPluginBinding) {
+    onAttachedToEngine(flutterPluginBinding.getApplicationContext(), flutterPluginBinding.getBinaryMessenger());
+  }
+
+  private void onAttachedToEngine(Context context, BinaryMessenger messenger) {
+    methodChannel = new MethodChannel(messenger, "square_reader_sdk");
+    init(context);
+    methodChannel.setMethodCallHandler(this);
+  }
+
+
+  @Override
+  public void onDetachedFromEngine(@NonNull FlutterPluginBinding flutterPluginBinding) {
+    methodChannel = null;
+  }
+
+  @Override
+  public void onAttachedToActivity(@NonNull ActivityPluginBinding activityPluginBinding) {
+    setContextForModules(activityPluginBinding.getActivity());
+  }
+
+  @Override
+  public void onDetachedFromActivityForConfigChanges() {
+  }
+
+  @Override
+  public void onReattachedToActivityForConfigChanges(@NonNull ActivityPluginBinding activityPluginBinding) {
+    setContextForModules(activityPluginBinding.getActivity());
+  }
+
+  @Override
+  public void onDetachedFromActivity() {
+
   }
 }

--- a/android/src/main/java/com/squareup/sdk/reader/flutter/SquareReaderSdkFlutterPlugin.java
+++ b/android/src/main/java/com/squareup/sdk/reader/flutter/SquareReaderSdkFlutterPlugin.java
@@ -32,17 +32,18 @@ import java.util.HashMap;
 
 public class SquareReaderSdkFlutterPlugin implements MethodCallHandler, FlutterPlugin, ActivityAware {
 
-  public static void registerWith(Registrar registrar) {
-    SquareReaderSdkFlutterPlugin instance = new SquareReaderSdkFlutterPlugin(registrar.activity());
-    instance.onAttachedToEngine(registrar.activity(), registrar.messenger());
-    methodChannel.setMethodCallHandler(instance);
-  }
-
   private static MethodChannel methodChannel;
   private AuthorizeModule authorizeModule;
   private CheckoutModule checkoutModule;
   private ReaderSettingsModule readerSettingsModule;
   private StoreCustomerCardModule storeCustomerCardModule;
+
+  public static void registerWith(Registrar registrar) {
+    SquareReaderSdkFlutterPlugin instance = new SquareReaderSdkFlutterPlugin(registrar.activity());
+    instance.onAttachedToEngine(registrar.activity(), registrar.messenger());
+    methodChannel.setMethodCallHandler(instance);
+
+  }
 
   private SquareReaderSdkFlutterPlugin(Context context) {
     init(context);

--- a/android/src/main/java/com/squareup/sdk/reader/flutter/StoreCustomerCardModule.java
+++ b/android/src/main/java/com/squareup/sdk/reader/flutter/StoreCustomerCardModule.java
@@ -16,6 +16,8 @@ limitations under the License.
 package com.squareup.sdk.reader.flutter;
 
 import android.app.Activity;
+import android.content.Context;
+
 import com.squareup.sdk.reader.ReaderSdk;
 import com.squareup.sdk.reader.checkout.Card;
 import com.squareup.sdk.reader.core.CallbackReference;
@@ -37,13 +39,13 @@ final class StoreCustomerCardModule {
   // flutter plugin debug messages
   private static final String FL_MESSAGE_STORE_CUSTOMER_CARD_ALREADY_IN_PROGRESS = "A store customer card operation is already in progress. Ensure that the in-progress store customer card is completed before calling startStoreCardAsync again.";
 
-  private final Activity currentActivity;
+  private Context currentContext;
   private final CardConverter cardConverter;
   private volatile CallbackReference storeCustomerCardCallbackRef;
 
 
-  public StoreCustomerCardModule(Activity activity) {
-    currentActivity = activity;
+  public StoreCustomerCardModule(Context context) {
+    currentContext = context;
     cardConverter = new CardConverter();
   }
 
@@ -76,6 +78,10 @@ final class StoreCustomerCardModule {
     };
 
     storeCustomerCardCallbackRef = ReaderSdk.customerCardManager().addStoreCardActivityCallback(storeCardActivityCallback);
-    ReaderSdk.customerCardManager().startStoreCardActivity(currentActivity, customerId);
+    ReaderSdk.customerCardManager().startStoreCardActivity(currentContext, customerId);
+  }
+
+  public void setContext(Context context) {
+    this.currentContext = context;
   }
 }

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -39,5 +39,8 @@
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
         </activity>
+        <meta-data
+            android:name="flutterEmbedding"
+            android:value="2" />
     </application>
 </manifest>

--- a/example/android/app/src/main/java/com/example/flutter/squareup/sdk/reader/MainActivity.java
+++ b/example/android/app/src/main/java/com/example/flutter/squareup/sdk/reader/MainActivity.java
@@ -15,8 +15,17 @@ limitations under the License.
 */
 package com.example.flutter.squareup.sdk.reader;
 
+import androidx.annotation.NonNull;
+
 import io.flutter.embedding.android.FlutterActivity;
+import io.flutter.embedding.engine.FlutterEngine;
+import io.flutter.plugins.GeneratedPluginRegistrant;
 
 public class MainActivity extends FlutterActivity {
+
+    @Override
+    public void configureFlutterEngine(@NonNull FlutterEngine flutterEngine) {
+        GeneratedPluginRegistrant.registerWith(flutterEngine);
+    }
 }
 

--- a/example/android/app/src/main/java/com/example/flutter/squareup/sdk/reader/MainActivity.java
+++ b/example/android/app/src/main/java/com/example/flutter/squareup/sdk/reader/MainActivity.java
@@ -15,15 +15,8 @@ limitations under the License.
 */
 package com.example.flutter.squareup.sdk.reader;
 
-import android.os.Bundle;
-import com.squareup.sdk.reader.ReaderSdk;
-import io.flutter.app.FlutterActivity;
-import io.flutter.plugins.GeneratedPluginRegistrant;
+import io.flutter.embedding.android.FlutterActivity;
 
 public class MainActivity extends FlutterActivity {
-  @Override
-  protected void onCreate(Bundle savedInstanceState) {
-    super.onCreate(savedInstanceState);
-    GeneratedPluginRegistrant.registerWith(this);
-  }
 }
+

--- a/example/android/app/src/main/java/com/example/flutter/squareup/sdk/reader/MainApplication.java
+++ b/example/android/app/src/main/java/com/example/flutter/squareup/sdk/reader/MainApplication.java
@@ -15,20 +15,31 @@ limitations under the License.
 */
 package com.example.flutter.squareup.sdk.reader;
 
+import android.app.Activity;
+
+import androidx.annotation.CallSuper;
+
 import com.squareup.sdk.reader.ReaderSdk;
 import io.flutter.app.FlutterApplication;
-import io.flutter.plugin.common.PluginRegistry;
-import io.flutter.plugins.GeneratedPluginRegistrant;
+import io.flutter.view.FlutterMain;
 
-public class MainApplication extends FlutterApplication implements PluginRegistry.PluginRegistrantCallback {
+public class MainApplication extends FlutterApplication {
+
   @Override
+  @CallSuper
   public void onCreate() {
     super.onCreate();
     ReaderSdk.initialize(this);
+    FlutterMain.startInitialization(this);
   }
 
-  @Override
-  public void registerWith(PluginRegistry registry) {
-    GeneratedPluginRegistrant.registerWith(registry);
+  private Activity mCurrentActivity = null;
+
+  public Activity getCurrentActivity() {
+    return mCurrentActivity;
+  }
+
+  public void setCurrentActivity(Activity mCurrentActivity) {
+    this.mCurrentActivity = mCurrentActivity;
   }
 }

--- a/example/android/app/src/main/java/com/example/flutter/squareup/sdk/reader/MainApplication.java
+++ b/example/android/app/src/main/java/com/example/flutter/squareup/sdk/reader/MainApplication.java
@@ -21,25 +21,17 @@ import androidx.annotation.CallSuper;
 
 import com.squareup.sdk.reader.ReaderSdk;
 import io.flutter.app.FlutterApplication;
+
 import io.flutter.view.FlutterMain;
+
 
 public class MainApplication extends FlutterApplication {
 
   @Override
-  @CallSuper
   public void onCreate() {
     super.onCreate();
     ReaderSdk.initialize(this);
     FlutterMain.startInitialization(this);
   }
 
-  private Activity mCurrentActivity = null;
-
-  public Activity getCurrentActivity() {
-    return mCurrentActivity;
-  }
-
-  public void setCurrentActivity(Activity mCurrentActivity) {
-    this.mCurrentActivity = mCurrentActivity;
-  }
 }


### PR DESCRIPTION
…r embedding and confirmed backwards compatibility.

<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

We can only accept your change after you sign this Individual Contributor License Agreement (CLA), you'll get the CLA link after create PR.

Learn more about the contributing rules from https://github.com/square/reader-sdk-flutter-plugin/blob/master/CONTRIBUTING.md
-->

## Summary
This change adds support for android v2 embedding so that we now support plugins that are pre update 1.12 and post update 1.12. 

See: https://flutter.dev/docs/development/packages-and-plugins/plugin-api-migration

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Related issues

Fix #

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/square/reader-sdk-flutter-plugin/blob/master/CHANGELOG.md for an example. -->

* Added embedding methods for the ReaderSDK plugin modules.
* Verified backwards compatibility. 
* Updated the example to use v2 embedding. 

## Test Plan

* Tested manually with the example pre and post 1.12 upgrade. 

<!-- Demonstrate the code is solid. Example: Manually test the quick start example works. -->