### PR TITLE
Add NSBluetoothAlwaysUsageDescription to Info.plist

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -4,7 +4,7 @@ PODS:
     - MTBBarcodeScanner
   - Flutter (1.0.0)
   - MTBBarcodeScanner (5.0.8)
-  - permission_handler (3.2.2):
+  - permission_handler (3.3.0):
     - Flutter
   - square_reader_sdk (2.0.0):
     - Flutter
@@ -31,9 +31,9 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   barcode_scan: 33f586d02270046fc6559135038b34b5754eaa4f
-  Flutter: 58dd7d1b27887414a370fcccb9e645c08ffd7a6a
+  Flutter: 0e3d915762c693b495b44d77113d4970485de6ec
   MTBBarcodeScanner: 5b97f10a037e2560ff104da413343c5ce9413911
-  permission_handler: d59f41439f5bc6c4d1005f3355e98f05ddc68ece
+  permission_handler: 67637977b227d62d46bfbf524f335f8568de5a73
   square_reader_sdk: a8320c16510030996d3cb76860ea91caf4e9d360
 
 PODFILE CHECKSUM: cb6b50d323655cc2ec3bd136559937da3b86ed80

--- a/example/ios/Runner/Info.plist
+++ b/example/ios/Runner/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSBluetoothAlwaysUsageDescription</key>
+	<string>This app integrates with Square for card processing. Square uses Bluetooth to connect your device to compatible hardware.</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleExecutable</key>


### PR DESCRIPTION
## Summary

Flutter Example was failing after successfully scanning QR due to missing key and description for `NSBluetoothAlwaysUsageDescription` in info.plist.

## Related issues

#45 
