### PR TITLE
Upgrading plugin to 2.3.0. Adding changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Changelog
 
+### v2.3.0 April 20, 2021
+
+* Adding support for Reader SDK 1.4.4+ on both Android and iOS.
+* On iOS, in Reader SDK 1.4.7+, the plugin now correctly handles the `SquareReaderSDK.xcframework` being downloaded
+
 ### v2.2.0 June 24, 2020
 
 * Added support for v2 flutter embeddings (flutter 1.12+).

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: square_reader_sdk
 description: An open source Flutter plugin for calling Square’s native Reader SDK implementations to take in-person payments on iOS and Android.
-version: 2.2.0
+version: 2.3.0
 author: Square Flutter Team <flutter-team@squareup.com>
 homepage: https://github.com/square/reader-sdk-flutter-plugin
 


### PR DESCRIPTION
## Summary

Upgrading the plugin to version 2.3.0.

* Adding support for Reader SDK 1.4.4+ on both Android and iOS.
* On iOS, in Reader SDK 1.4.7+, the plugin now correctly handles the `SquareReaderSDK.xcframework` being downloaded