### PR TITLE
Updating pubspec.yaml to conform with validation changes

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,11 +1,11 @@
 name: square_reader_sdk
 description: An open source Flutter plugin for calling Square’s native Reader SDK implementations to take in-person payments on iOS and Android.
 version: 2.3.0
-author: Square Flutter Team <flutter-team@squareup.com>
 homepage: https://github.com/square/reader-sdk-flutter-plugin
 
 environment:
   sdk: ">=2.0.0 <3.0.0"
+  flutter: ">=1.10.0"
 
 dependencies:
   flutter:
@@ -22,5 +22,9 @@ dev_dependencies:
 # The following section is specific to Flutter.
 flutter:
   plugin:
-    androidPackage: com.squareup.sdk.reader.flutter
-    pluginClass: SquareReaderSdkFlutterPlugin
+    platforms:
+      android:
+        package: com.squareup.sdk.reader.flutter
+        pluginClass: SquareReaderSdkFlutterPlugin
+      ios:
+        pluginClass: SquareReaderSdkFlutterPlugin


### PR DESCRIPTION
## Summary

A few things changed since we last published:
1. The `authors` key is deprecated
2. The `flutter.plugin` key has been updated. We now use the new `platforms` key

These pieces were causing validation errors when running `flutter pub publish --dry-run`  