### PR TITLE
Updating to 3.0.0 since Null Safety support is a breaking change.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Changelog
 
-### v2.4.0 July 23rd, 2021
+### v3.0.0 July 23rd, 2021
 
 * Update package dependencies to latest versions for Null Safety support.
 * Plugin and Example code migration to null safety.

--- a/ios/square_reader_sdk.podspec
+++ b/ios/square_reader_sdk.podspec
@@ -3,7 +3,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'square_reader_sdk'
-  s.version          = '2.4.0'
+  s.version          = '3.0.0'
   s.summary          = 'iOS part of a flutter plugin for Square Reader SDK.'
   s.description      = <<-DESC
 iOS part of a flutter plugin for Square Reader SDK.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: square_reader_sdk
 description: An open source Flutter plugin for calling Square’s native Reader SDK implementations to take in-person payments on iOS and Android.
-version: 2.4.0
+version: 3.0.0
 homepage: https://github.com/square/reader-sdk-flutter-plugin
 
 environment:


### PR DESCRIPTION
## Summary

This only updates the version number, as we never officially published 2.4.0.

As specified [here](https://dart.dev/null-safety/migration-guide#package-version), a Null Safety update is actually a major version change, and we should mark it accordingly.

## Changelog

* Update package dependencies to latest versions for Null Safety support.
* Plugin and Example code migration to null safety.
* Dart version : 2.12

## Test Plan

<!-- Demonstrate the code is solid. Example: Manually test the quick start example works. -->