### PR TITLE
Bump reader SDK version to 1.5.1 in plugin.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,6 @@ In addition to this README, the following is available in the
 
 * Flutter version 2.0 or higher
 * Dart version 2.12 or higher
-* A version of Flutter greater than 2.0 is required for v2 embedding support. Any application that uses v1 embeddings for android will still be backwards compatible and supported.
    
 ### Android
 

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ solutions on Android and iOS.
 The Flutter plugin for Reader SDK acts as a wrapper on the native SDKs and is
 currently compatible with the following native Reader SDK versions:
 
-  * iOS: 1.4.4 and above
-  * Android: 1.4.4 and above
+  * iOS: 1.5.2 and above
+  * Android: 1.5.1 and above
 
 Try the [sample app] to see the plugin in action or follow the instructions in
 the [getting started guide] to build a custom solution from scratch.
@@ -39,8 +39,10 @@ In addition to this README, the following is available in the
 
 ### Flutter
 
-A version of Flutter greater than 1.12 is required for v2 embedding support. Any application that uses v1 embeddings for android will still be backwards compatible and supported.
-  
+* Flutter version 2.0 or higher
+* Dart version 2.12 or higher
+* A version of Flutter greater than 2.0 is required for v2 embedding support. Any application that uses v1 embeddings for android will still be backwards compatible and supported.
+   
 ### Android
 
 * minSdkVersion is API 21 (Lollipop 5.0) or higher.
@@ -56,6 +58,7 @@ A version of Flutter greater than 1.12 is required for v2 embedding support. Any
 * Xcode version: 10.2 or greater.
 * iOS Base SDK: 11.1 or greater.
 * Deployment target: iOS 11.0 or greater.
+* Currently, this plugin will work only on Mac with Intel processor. This will not work on Mac with M1 chip.
 
 
 ## Reader SDK requirements and limitations

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -44,7 +44,7 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 def DEFAULT_PLAY_SERVICES_BASE_VERSION = '16.0.1'
-def READER_SDK_VERSION = '[1.4.4, 2.0)'
+def READER_SDK_VERSION = '[1.5.1, 2.0)'
 
 android {
     compileSdkVersion 29

--- a/doc/get-started.md
+++ b/doc/get-started.md
@@ -54,7 +54,7 @@ dependencies:
 
   ...
 
-  square_reader_sdk: ^2.0.0
+  square_reader_sdk: ^3.0.0
 ```
 
 

--- a/doc/troubleshooting.md
+++ b/doc/troubleshooting.md
@@ -2,6 +2,44 @@
 
 Likely causes and solutions for common problems.
 
+## I upgraded to Flutter 2.5.0 and I get a linker error on Mac
+
+### The problem
+
+You're using Flutter 2.5.0 on a Mac.  When you run `flutter run`, you hit this error:
+
+```
+error: linker command failed with exit code 1 (use -v to see invocation) ld: building for iOS Simulator, but linking in dylib built for iOS
+```
+Deploying to a physical device is fine though.
+
+
+### Likely cause
+
+Flutter 2.5.0 introduced M1 support.  The In-App-Payments SDK does not have M1 support and does not allow creating builds that target arm64 simulators, resulting in the error above.
+
+### Solution
+
+Manually change your app settings to exclude arm64 simulator support.  Xcode won't try to build against this architecture so there shouldn't be any errors.
+
+**IMPORTANT NOTE:**
+**This solution will only work on intel-based macs.  M1 macs are unsupported by our SDK without any workarounds available**
+
+1.) Add the following to the bottom of your podfile:
+```
+post_install do |installer|
+  installer.pods_project.build_configurations.each do |config|
+    config.build_settings["EXCLUDED_ARCHS[sdk=iphonesimulator*]"] = "arm64"
+    config.build_settings["ONLY_ACTIVE_ARCH"] = "YES"
+  end
+end
+```
+
+2.) run `pod install`
+
+3.) You should be able to run the Reader SDK using the latest version of flutter on intel-based macs.
+
+
 ## I get Xcode compile errors when building Reader SDK
 
 ### The problem

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -23,9 +23,10 @@ if (flutterVersionName == null) {
 
 apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
+apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 30
 
     lintOptions {
         disable 'InvalidPackage'
@@ -35,7 +36,7 @@ android {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "com.example.flutter.squareup.sdk.reader"
         minSdkVersion 26
-        targetSdkVersion 28
+        targetSdkVersion 30
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
@@ -51,6 +52,11 @@ android {
             shrinkResources false
         }
     }
+
+    packagingOptions {
+        exclude("META-INF/*.kotlin_module")
+    }
+
     dexOptions {
         preDexLibraries true
         jumboMode true

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -1,11 +1,14 @@
 buildscript {
+    ext.kotlin_version = '1.5.0'
+
     repositories {
         google()
         jcenter()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.3.1'
+        classpath 'com.android.tools.build:gradle:4.1.3'
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
 
@@ -19,7 +22,7 @@ allprojects {
 ext {
     // Override the reader sdk version with the this parameter
     // make sure the version is above min version 1.3.3
-    readerSdkVersion = "[1.4.4, 2.0)"
+    readerSdkVersion = "[1.5.1, 2.0)"
 }
 
 rootProject.buildDir = '../build'

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip

--- a/example/ios/Flutter/AppFrameworkInfo.plist
+++ b/example/ios/Flutter/AppFrameworkInfo.plist
@@ -21,6 +21,6 @@
   <key>CFBundleVersion</key>
   <string>1.0</string>
   <key>MinimumOSVersion</key>
-  <string>8.0</string>
+  <string>9.0</string>
 </dict>
 </plist>

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -57,6 +57,8 @@ post_install do |installer|
             ## dart: PermissionGroup.bluetooth
             'PERMISSION_BLUETOOTH=1',
           ]
+          config.build_settings["EXCLUDED_ARCHS[sdk=iphonesimulator*]"] = "arm64"
+          config.build_settings["ONLY_ACTIVE_ARCH"] = "YES"
     end
   end
 end

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -6,7 +6,7 @@ PODS:
   - MTBBarcodeScanner (5.0.8)
   - "permission_handler (5.1.0+2)":
     - Flutter
-  - square_reader_sdk (2.1.0):
+  - square_reader_sdk (3.0.0):
     - Flutter
 
 DEPENDENCIES:
@@ -31,11 +31,11 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   barcode_scan: 33f586d02270046fc6559135038b34b5754eaa4f
-  Flutter: 434fef37c0980e73bb6479ef766c45957d4b510c
+  Flutter: 50d75fe2f02b26cc09d224853bb45737f8b3214a
   MTBBarcodeScanner: 5b97f10a037e2560ff104da413343c5ce9413911
   permission_handler: ccb20a9fad0ee9b1314a52b70b76b473c5f8dab0
-  square_reader_sdk: ca868b01a8f3ca2b5813d6fbc5bb2731fbf4d0fa
+  square_reader_sdk: c180851c81247aed31ef44b8b7d756b12232e078
 
-PODFILE CHECKSUM: 820e703ef7253d6bc9c2ea0d2ae80dc03ce6f6ed
+PODFILE CHECKSUM: b8f274c393321e56edc8235d386da868707de841
 
 COCOAPODS: 1.10.1

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -60,7 +60,7 @@ ThemeData _buildTheme() {
           fontWeight: FontWeight.w600,
           color: Colors.white,
         ),
-        body1: TextStyle(
+        bodyText1: TextStyle(
           fontSize: 24.0,
           fontWeight: FontWeight.w600,
           color: Colors.white,


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

We can only accept your change after you sign this Individual Contributor License Agreement (CLA), you'll get the CLA link after create PR.

Learn more about the contributing rules from https://github.com/square/reader-sdk-flutter-plugin/blob/master/CONTRIBUTING.md
-->

## Summary

- Bump Reader SDK version to 1.5.1 in plugin
- Workaround to build iOS project for Flutter 2.5.0
- Update documentation

## Related issues

Fix #

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/square/reader-sdk-flutter-plugin/blob/master/CHANGELOG.md for an example. -->

## Test Plan

<!-- Demonstrate the code is solid. Example: Manually test the quick start example works. -->