### PR TITLE
Support for Flutter 3, Android 12 and most recent iOS SDK

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ android/.settings/org.eclipse.buildship.core.prefs
 .clang-format
 android/bin
 .vscode/launch.json
+
+.idea/

--- a/README.md
+++ b/README.md
@@ -19,8 +19,6 @@ package <YOUR_PACKAGE_NAME>;
 
 - import com.squareup.sdk.reader.ReaderSdk;   
 import io.flutter.app.FlutterApplication;
-import io.flutter.view.FlutterMain;
-
 
 public class MainApplication extends FlutterApplication {
 

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ solutions on Android and iOS.
 The Flutter plugin for Reader SDK acts as a wrapper on the native SDKs and is
 currently compatible with the following native Reader SDK versions:
 
-  * iOS: 1.5.2 and above
-  * Android: 1.5.1 and above
+  * iOS: 1.6.0 and above
+  * Android: 1.6.1 and above
 
 Try the [sample app] to see the plugin in action or follow the instructions in
 the [getting started guide] to build a custom solution from scratch.
@@ -39,13 +39,13 @@ In addition to this README, the following is available in the
 
 ### Flutter
 
-* Flutter version 2.0 or higher
+* Flutter version 3.0 or higher
 * Dart version 2.12 or higher
    
 ### Android
 
-* minSdkVersion is API 21 (Lollipop 5.0) or higher.
-* Android SDK platform: API 29.
+* minSdkVersion is API 24 or higher.
+* Android SDK platform: API 31.
 * Android SDK build tools: 28.0.2
 * Android Gradle Plugin: 3.0.0 or greater.
 * Support library: 26.0.2
@@ -57,7 +57,6 @@ In addition to this README, the following is available in the
 * Xcode version: 10.2 or greater.
 * iOS Base SDK: 11.1 or greater.
 * Deployment target: iOS 11.0 or greater.
-* Currently, this plugin will work only on Mac with Intel processor. This will not work on Mac with M1 chip.
 
 
 ## Reader SDK requirements and limitations

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ solutions on Android and iOS.
 
 Remove initialize method from `onCreate` method in your application class in Android portion
 
-```java
+```diff
 package <YOUR_PACKAGE_NAME>;
 
 - import com.squareup.sdk.reader.ReaderSdk;   

--- a/README.md
+++ b/README.md
@@ -10,6 +10,31 @@ authorization, transaction processing, and Reader management.
 Use Square's official Flutter plugin for Reader SDK to build in-person payment
 solutions on Android and iOS.
 
+## Migration from 3.x to 4.x
+
+Remove initialize method from `onCreate` method in your application class in Android portion
+
+```java
+package <YOUR_PACKAGE_NAME>;
+
+- import com.squareup.sdk.reader.ReaderSdk;   
+import io.flutter.app.FlutterApplication;
+import io.flutter.view.FlutterMain;
+
+
+public class MainApplication extends FlutterApplication {
+
+ @Override
+ public void onCreate() {
+   super.onCreate();
+-   ReaderSdk.initialize(this);
+ }   
+}
+```
+
+### If you targeting SDK 31 and above
+Go to your app and add code to request `BLUETOOTH_SCAN` and `BLUETOOTH_CONNECT` permissions before
+you invoke any of Reader plugin method.
 
 ## How to use
 
@@ -39,7 +64,7 @@ In addition to this README, the following is available in the
 
 ### Flutter
 
-* Flutter version 3.0 or higher
+* Flutter version 2.0 or higher
 * Dart version 2.12 or higher
    
 ### Android

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -58,11 +58,6 @@ android {
     lintOptions {
         disable 'InvalidPackage'
     }
-    dexOptions {
-        preDexLibraries true
-        jumboMode true
-        keepRuntimeAnnotatedClasses false
-    }
 }
 
 dependencies {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -47,11 +47,11 @@ def DEFAULT_PLAY_SERVICES_BASE_VERSION = '16.0.1'
 def READER_SDK_VERSION = '[1.5.1, 2.0)'
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 33
 
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 29
+        targetSdkVersion 33
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         multiDexEnabled true
     }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -58,6 +58,14 @@ android {
     lintOptions {
         disable 'InvalidPackage'
     }
+    dexOptions {
+        // Ensures incremental builds remain fast
+        preDexLibraries true
+        // Required to build with Reader SDK
+        jumboMode true
+        // Required to build with Reader SDK
+        keepRuntimeAnnotatedClasses false
+    }
 }
 
 dependencies {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -47,11 +47,11 @@ def DEFAULT_PLAY_SERVICES_BASE_VERSION = '16.0.1'
 def READER_SDK_VERSION = '[1.5.1, 2.0)'
 
 android {
-    compileSdkVersion 33
+    compileSdkVersion 32
 
     defaultConfig {
-        minSdkVersion 21
-        targetSdkVersion 33
+        minSdkVersion 24
+        targetSdkVersion 32
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         multiDexEnabled true
     }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -51,7 +51,7 @@ android {
 
     defaultConfig {
         minSdkVersion 24
-        targetSdkVersion 32
+        targetSdkVersion 31
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         multiDexEnabled true
     }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -44,7 +44,7 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 def DEFAULT_PLAY_SERVICES_BASE_VERSION = '16.0.1'
-def READER_SDK_VERSION = '[1.5.1, 2.0)'
+def READER_SDK_VERSION = '[1.6.1, 2.0)'
 
 android {
     compileSdkVersion 32

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,16 +1,14 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
   package="com.squareup.readersdkflutterplugin">
 
-  <uses-permission
-        android:name="android.permission.BLUETOOTH"
-        android:maxSdkVersion="30" />
-    <uses-permission
-        android:name="android.permission.BLUETOOTH_ADMIN"
-        android:maxSdkVersion="30" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+
+    <!-- Keep permission without max sdk limit to make them work with target sdk lower than 30 on devices with android 12 and 13 -->
+    <uses-permission android:name="android.permission.BLUETOOTH" />
+    <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
     <!-- API 31+ -->
     <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
     <uses-permission android:name="android.permission.BLUETOOTH_SCAN" />
-    <uses-permission android:name="android.permission.BLUETOOTH_ADVERTISE" />
 
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />

--- a/android/src/main/java/com/squareup/sdk/reader/flutter/SquareReaderSdkFlutterPlugin.java
+++ b/android/src/main/java/com/squareup/sdk/reader/flutter/SquareReaderSdkFlutterPlugin.java
@@ -15,6 +15,7 @@ limitations under the License.
 */
 package com.squareup.sdk.reader.flutter;
 
+import android.app.Activity;
 import android.content.Context;
 
 import androidx.annotation.NonNull;
@@ -30,6 +31,8 @@ import io.flutter.plugin.common.MethodChannel.Result;
 import io.flutter.plugin.common.PluginRegistry.Registrar;
 import java.util.HashMap;
 
+import com.squareup.sdk.reader.ReaderSdk;
+
 public class SquareReaderSdkFlutterPlugin implements MethodCallHandler, FlutterPlugin, ActivityAware {
 
   private static MethodChannel methodChannel;
@@ -37,6 +40,8 @@ public class SquareReaderSdkFlutterPlugin implements MethodCallHandler, FlutterP
   private CheckoutModule checkoutModule;
   private ReaderSettingsModule readerSettingsModule;
   private StoreCustomerCardModule storeCustomerCardModule;
+  private Activity currentActivity;
+  private boolean initialized = false;
 
   public static void registerWith(Registrar registrar) {
     SquareReaderSdkFlutterPlugin instance = new SquareReaderSdkFlutterPlugin(registrar.activity());
@@ -62,38 +67,55 @@ public class SquareReaderSdkFlutterPlugin implements MethodCallHandler, FlutterP
     storeCustomerCardModule = new StoreCustomerCardModule(context);
   }
 
-  private void setContextForModules(final Context context) {
-    checkoutModule.setContext(context);
-    readerSettingsModule.setContext(context);
-    storeCustomerCardModule.setContext(context);
+  private void setContextForModules(final Activity activity) {
+    currentActivity = activity;
+    checkoutModule.setContext(activity);
+    readerSettingsModule.setContext(activity);
+    storeCustomerCardModule.setContext(activity);
   }
 
   @Override
   public void onMethodCall(MethodCall call, Result result) {
+    if (!initialized) {
+      ReaderSdk.initialize(currentActivity.getApplication());
+      initialized = true;
+    }
+
     String methodName = call.method;
-    if (methodName.equals("isAuthorized")) {
-      authorizeModule.isAuthorized(result);
-    } else if (methodName.equals("isAuthorizationInProgress")) {
-      authorizeModule.isAuthorizationInProgress(result);
-    } else if (methodName.equals("authorizedLocation")) {
-      authorizeModule.authorizedLocation(result);
-    } else if (methodName.equals("authorize")) {
-      String authCode = call.argument("authCode");
-      authorizeModule.authorize(authCode, result);
-    } else if (methodName.equals("canDeauthorize")) {
-      authorizeModule.canDeauthorize(result);
-    } else if (methodName.equals("deauthorize")) {
-      authorizeModule.deauthorize(result);
-    } else if (methodName.equals("startCheckout")) {
-      HashMap<String, Object> checkoutParams = call.argument("checkoutParams");
-      checkoutModule.startCheckout(checkoutParams, result);
-    } else if (methodName.equals("startReaderSettings")) {
-      readerSettingsModule.startReaderSettings(result);
-    } else if (methodName.equals("startStoreCard")) {
-      String customerId = call.argument("customerId");
-      storeCustomerCardModule.startStoreCard(customerId, result);
-    } else {
-      result.notImplemented();
+    switch (methodName) {
+      case "isAuthorized":
+        authorizeModule.isAuthorized(result);
+        break;
+      case "isAuthorizationInProgress":
+        authorizeModule.isAuthorizationInProgress(result);
+        break;
+      case "authorizedLocation":
+        authorizeModule.authorizedLocation(result);
+        break;
+      case "authorize":
+        String authCode = call.argument("authCode");
+        authorizeModule.authorize(authCode, result);
+        break;
+      case "canDeauthorize":
+        authorizeModule.canDeauthorize(result);
+        break;
+      case "deauthorize":
+        authorizeModule.deauthorize(result);
+        break;
+      case "startCheckout":
+        HashMap<String, Object> checkoutParams = call.argument("checkoutParams");
+        checkoutModule.startCheckout(checkoutParams, result);
+        break;
+      case "startReaderSettings":
+        readerSettingsModule.startReaderSettings(result);
+        break;
+      case "startStoreCard":
+        String customerId = call.argument("customerId");
+        storeCustomerCardModule.startStoreCard(customerId, result);
+        break;
+      default:
+        result.notImplemented();
+        break;
     }
   }
 

--- a/android/src/main/java/com/squareup/sdk/reader/flutter/SquareReaderSdkFlutterPlugin.java
+++ b/android/src/main/java/com/squareup/sdk/reader/flutter/SquareReaderSdkFlutterPlugin.java
@@ -41,7 +41,7 @@ public class SquareReaderSdkFlutterPlugin implements MethodCallHandler, FlutterP
   private ReaderSettingsModule readerSettingsModule;
   private StoreCustomerCardModule storeCustomerCardModule;
   private Activity currentActivity;
-  private boolean initialized = false;
+  private static boolean sdkInitialized = false;
 
   public static void registerWith(Registrar registrar) {
     SquareReaderSdkFlutterPlugin instance = new SquareReaderSdkFlutterPlugin(registrar.activity());
@@ -75,11 +75,8 @@ public class SquareReaderSdkFlutterPlugin implements MethodCallHandler, FlutterP
   }
 
   @Override
-  public void onMethodCall(MethodCall call, Result result) {
-    if (!initialized) {
-      ReaderSdk.initialize(currentActivity.getApplication());
-      initialized = true;
-    }
+  public void onMethodCall(MethodCall call, @NonNull Result result) {
+    initializeReaderSdk();
 
     String methodName = call.method;
     switch (methodName) {
@@ -153,5 +150,14 @@ public class SquareReaderSdkFlutterPlugin implements MethodCallHandler, FlutterP
   @Override
   public void onDetachedFromActivity() {
 
+  }
+
+  private void initializeReaderSdk() {
+    if (sdkInitialized) {
+      return;
+    }
+
+    ReaderSdk.initialize(currentActivity.getApplication());
+    sdkInitialized = true;
   }
 }

--- a/doc/get-started.md
+++ b/doc/get-started.md
@@ -91,8 +91,8 @@ Flutter library as a resource. The key installation steps are outlined below.
     ```
     android {
       defaultConfig {
-        minSdkVersion 21
-        targetSdkVersion 29
+        minSdkVersion 24
+        targetSdkVersion 32
         multiDexEnabled true
       }
       ...
@@ -113,55 +113,6 @@ Flutter library as a resource. The key installation steps are outlined below.
       ...
     }
     ```
-1. Open the `MainApplication` class for your project. **Note that `MainApplication`
-is not created by default through `flutter create <Project>`, so you may need to
-create it**. Add code to extend the Flutter Application class
-(`FlutterApplication`) that imports and initializes Reader SDK:
-
-    ```java
-    package <YOUR_PACKAGE_NAME>;
-
-    import com.squareup.sdk.reader.ReaderSdk;   
-    import io.flutter.app.FlutterApplication;
-    import io.flutter.view.FlutterMain;
-   
-   
-   public class MainApplication extends FlutterApplication {
-   
-     @Override
-     public void onCreate() {
-       super.onCreate();
-       ReaderSdk.initialize(this);
-       FlutterMain.startInitialization(this);
-     }   
-    }
-    ```
-
-1. If you create `MainApplication` class in above step, update `AndroidManifest.xml` in your project:
-    ```xml
-      <application
-        <!-- use custom "MainApplication" class instead of "io.flutter.app.FlutterApplication" -->
-        android:name=".MainApplication" 
-        ... />
-      </application>
-    ```
-1. If you are using any minor version of Flutter 1.12 you may need to add this method to your `MainActivity`.
- However, if you are using Flutter version 1.16+ you will not need the additional method below.   
-    ```java
-     import androidx.annotation.NonNull;
-     
-     import io.flutter.embedding.android.FlutterActivity;
-     import io.flutter.embedding.engine.FlutterEngine;
-     import io.flutter.plugins.GeneratedPluginRegistrant;
-     
-     public class MainActivity extends FlutterActivity {
-     
-         @Override
-         public void configureFlutterEngine(@NonNull FlutterEngine flutterEngine) {
-             GeneratedPluginRegistrant.registerWith(flutterEngine);
-         }
-     }
-    ``` 
 
 ## Step 5: Configure Xcode for Reader SDK (iOS)
 
@@ -283,6 +234,9 @@ try {
 
 > For iOS, you will also need to add code to your Flutter project to request
 > location and microphone permissions.
+> 
+> For Android 12, you will also need to add code to your Flutter project to request
+> bluetoothScan and bluetoothConnect permissions.
 
 ---
 

--- a/doc/get-started.md
+++ b/doc/get-started.md
@@ -92,7 +92,7 @@ Flutter library as a resource. The key installation steps are outlined below.
     android {
       defaultConfig {
         minSdkVersion 24
-        targetSdkVersion 32
+        targetSdkVersion 31
         multiDexEnabled true
       }
       ...

--- a/doc/get-started.md
+++ b/doc/get-started.md
@@ -157,8 +157,6 @@ information on installing Reader SDK for iOS, see the
    **Deployment Target** is set to 11.0+.
 1. In Xcode, open the **General** tab for your app target and make sure the
    **Landscape Left** and **Landscape Right** device orientations are supported.
-1. In Xcode, open the **Build Settings** tab for your app target and add **$(PROJECT_DIR)**
-   to **Framework Search Paths**.
 1. If you are on Xcode 10+, set build system to `Legacy Build System`
 1. Update your Info.plist with the following key:value pairs in the **Info** tab
    for your application target to explain why your application requires these

--- a/doc/get-started.md
+++ b/doc/get-started.md
@@ -54,7 +54,7 @@ dependencies:
 
   ...
 
-  square_reader_sdk: ^3.0.0
+  square_reader_sdk: ^4.0.0
 ```
 
 
@@ -138,6 +138,9 @@ information on installing Reader SDK for iOS, see the
     --app-id YOUR_SQUARE_READER_APP_ID                                    \
     --repo-password YOUR_SQUARE_READER_REPOSITORY_PASSWORD
     ```
+   
+    Optionally you can use `--version` key to specify what version of iOS Reader SDK
+    you want to install.
 1. Add Reader SDK to your Xcode project:
    * Open `Runner.xcworkspace` in Xcode.
    * Open the **General** tab for your app target in Xcode.

--- a/doc/troubleshooting.md
+++ b/doc/troubleshooting.md
@@ -20,24 +20,7 @@ Flutter 2.5.0 introduced M1 support.  The In-App-Payments SDK does not have M1 s
 
 ### Solution
 
-Manually change your app settings to exclude arm64 simulator support.  Xcode won't try to build against this architecture so there shouldn't be any errors.
-
-**IMPORTANT NOTE:**
-**This solution will only work on intel-based macs.  M1 macs are unsupported by our SDK without any workarounds available**
-
-1.) Add the following to the bottom of your podfile:
-```
-post_install do |installer|
-  installer.pods_project.build_configurations.each do |config|
-    config.build_settings["EXCLUDED_ARCHS[sdk=iphonesimulator*]"] = "arm64"
-    config.build_settings["ONLY_ACTIVE_ARCH"] = "YES"
-  end
-end
-```
-
-2.) run `pod install`
-
-3.) You should be able to run the Reader SDK using the latest version of flutter on intel-based macs.
+Ensure that you using iOS SDK version 1.6.0 and above
 
 
 ## I get Xcode compile errors when building Reader SDK

--- a/example/analysis_options.yaml
+++ b/example/analysis_options.yaml
@@ -1,6 +1,4 @@
 analyzer:
-  language:
-    enableSuperMixins: true
   errors:
     # treat missing required parameters as a warning (not a hint)
     missing_required_param: warning

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -36,7 +36,7 @@ android {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "com.example.flutter.squareup.sdk.reader"
         minSdkVersion 26
-        targetSdkVersion 32
+        targetSdkVersion 31
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -26,7 +26,7 @@ apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 32
+    compileSdkVersion 33
 
     lintOptions {
         disable 'InvalidPackage'

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -7,22 +7,6 @@
     -->
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.CAMERA" />
-    <!-- The FOREGROUND_SERVICE permission is required for API level 28 and greater. -->
-    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
-
-     <uses-permission
-        android:name="android.permission.BLUETOOTH"
-        android:maxSdkVersion="30" />
-    <uses-permission
-        android:name="android.permission.BLUETOOTH_ADMIN"
-        android:maxSdkVersion="30" />
-    <!-- API 31+ -->
-    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
-    <uses-permission android:name="android.permission.BLUETOOTH_SCAN" />
-    <uses-permission android:name="android.permission.BLUETOOTH_ADVERTISE" />
-
-    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
-    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
 
 
     <!-- io.flutter.app.FlutterApplication is an android.app.Application that

--- a/example/android/app/src/main/java/com/example/flutter/squareup/sdk/reader/MainActivity.kt
+++ b/example/android/app/src/main/java/com/example/flutter/squareup/sdk/reader/MainActivity.kt
@@ -15,23 +15,8 @@ limitations under the License.
 */
 package com.example.flutter.squareup.sdk.reader;
 
-import android.app.Activity;
+import io.flutter.embedding.android.FlutterActivity
 
-import androidx.annotation.CallSuper;
-
-import com.squareup.sdk.reader.ReaderSdk;
-import io.flutter.app.FlutterApplication;
-
-import io.flutter.view.FlutterMain;
-
-
-public class MainApplication extends FlutterApplication {
-
-  @Override
-  public void onCreate() {
-    super.onCreate();
-    ReaderSdk.initialize(this);
-    FlutterMain.startInitialization(this);
-  }
-
+class MainActivity: FlutterActivity() {
 }
+

--- a/example/android/app/src/main/java/com/example/flutter/squareup/sdk/reader/MainApplication.kt
+++ b/example/android/app/src/main/java/com/example/flutter/squareup/sdk/reader/MainApplication.kt
@@ -15,17 +15,7 @@ limitations under the License.
 */
 package com.example.flutter.squareup.sdk.reader;
 
-import androidx.annotation.NonNull;
+import io.flutter.app.FlutterApplication
 
-import io.flutter.embedding.android.FlutterActivity;
-import io.flutter.embedding.engine.FlutterEngine;
-import io.flutter.plugins.GeneratedPluginRegistrant;
-
-public class MainActivity extends FlutterActivity {
-
-    @Override
-    public void configureFlutterEngine(@NonNull FlutterEngine flutterEngine) {
-        GeneratedPluginRegistrant.registerWith(flutterEngine);
-    }
+class MainApplication: FlutterApplication() {
 }
-

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -3,7 +3,6 @@ buildscript {
 
     repositories {
         google()
-        jcenter()
         mavenCentral()
     }
 
@@ -17,14 +16,14 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 
 ext {
     // Override the reader sdk version with the this parameter
-    // make sure the version is above min version 1.3.3
-    readerSdkVersion = "[1.5.1, 2.0)"
+    // make sure the version is above min version 1.6.1
+    readerSdkVersion = "[1.6.1, 2.0)"
 }
 
 rootProject.buildDir = '../build'

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.5.0'
+    ext.kotlin_version = '1.6.10'
 
     repositories {
         google()
@@ -8,7 +8,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.2.2'
+        classpath 'com.android.tools.build:gradle:7.1.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath 'com.dipien:bye-bye-jetifier:1.2.1'
     }

--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -18,7 +18,7 @@ android.enableJetifier=true
 ## Uncomment the properties below and set their correct value.
 
 ## The Application ID displayed on the Credentials tab in the Square Application Control Panel.
-SQUARE_READER_SDK_APPLICATION_ID=sq0idp-JbODTpQu7Kp0dsyFO1xPRw
+SQUARE_READER_SDK_APPLICATION_ID=
 
 ## The Application Secret from the OAuth tab in the Square Application Control Panel.
-SQUARE_READER_SDK_REPOSITORY_PASSWORD=zpqds7b7ply2shkm7s67rujvnaqnknsp2gupjepaf2376wab5hja
+SQUARE_READER_SDK_REPOSITORY_PASSWORD=

--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -18,7 +18,7 @@ android.enableJetifier=true
 ## Uncomment the properties below and set their correct value.
 
 ## The Application ID displayed on the Credentials tab in the Square Application Control Panel.
-SQUARE_READER_SDK_APPLICATION_ID=
+#SQUARE_READER_SDK_APPLICATION_ID=
 
 ## The Application Secret from the OAuth tab in the Square Application Control Panel.
-SQUARE_READER_SDK_REPOSITORY_PASSWORD=
+#SQUARE_READER_SDK_REPOSITORY_PASSWORD=

--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -12,17 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-#org.gradle.jvmargs=-Xmx4g
+org.gradle.jvmargs=-Xmx4g
 android.useAndroidX=true
 android.enableJetifier=true
-#android.jetifier.ignorelist=moshi-1.13.0
-#android.jetifier.blacklist=moshi-1.13.0
-android.jetifier.blacklist = bcprov-jdk15on
-org.gradle.jvmargs=-Xmx1536M --add-exports=java.base/sun.nio.ch=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.lang.reflect=ALL-UNNAMED --add-opens=java.base/java.io=ALL-UNNAMED --add-exports=jdk.unsupported/sun.misc=ALL-UNNAMED
 ## Uncomment the properties below and set their correct value.
 
 ## The Application ID displayed on the Credentials tab in the Square Application Control Panel.
-## SQUARE_READER_SDK_APPLICATION_ID=
+SQUARE_READER_SDK_APPLICATION_ID=sq0idp-JbODTpQu7Kp0dsyFO1xPRw
 
 ## The Application Secret from the OAuth tab in the Square Application Control Panel.
-## SQUARE_READER_SDK_REPOSITORY_PASSWORD=
+SQUARE_READER_SDK_REPOSITORY_PASSWORD=zpqds7b7ply2shkm7s67rujvnaqnknsp2gupjepaf2376wab5hja

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.1.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -28,6 +28,8 @@ require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelpe
 flutter_ios_podfile_setup
 
 target 'Runner' do
+  use_frameworks!
+  use_modular_headers!
   flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
 end
 
@@ -57,8 +59,11 @@ post_install do |installer|
             ## dart: PermissionGroup.bluetooth
             'PERMISSION_BLUETOOTH=1',
           ]
-          config.build_settings["EXCLUDED_ARCHS[sdk=iphonesimulator*]"] = "arm64"
-          config.build_settings["ONLY_ACTIVE_ARCH"] = "YES"
+    end
+    # Barcode scanner has stale deployment target
+    target.build_configurations.each do |config|
+          #config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '11.0'
+          config.build_settings.delete 'IPHONEOS_DEPLOYMENT_TARGET'
     end
   end
 end

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,47 +1,53 @@
 PODS:
-  - barcode_scan (0.0.1):
+  - barcode_scan2 (0.0.1):
     - Flutter
     - MTBBarcodeScanner
-  - Firebase/CoreOnly (8.15.0):
-    - FirebaseCore (= 8.15.0)
-  - firebase_core (1.16.0):
-    - Firebase/CoreOnly (= 8.15.0)
+    - SwiftProtobuf
+  - Firebase/CoreOnly (9.3.0):
+    - FirebaseCore (= 9.3.0)
+  - firebase_core (1.20.1):
+    - Firebase/CoreOnly (= 9.3.0)
     - Flutter
-  - FirebaseCore (8.15.0):
-    - FirebaseCoreDiagnostics (~> 8.0)
+  - FirebaseCore (9.3.0):
+    - FirebaseCoreDiagnostics (~> 9.0)
+    - FirebaseCoreInternal (~> 9.0)
     - GoogleUtilities/Environment (~> 7.7)
     - GoogleUtilities/Logger (~> 7.7)
-  - FirebaseCoreDiagnostics (8.15.0):
-    - GoogleDataTransport (~> 9.1)
+  - FirebaseCoreDiagnostics (9.4.0):
+    - GoogleDataTransport (< 10.0.0, >= 9.1.4)
     - GoogleUtilities/Environment (~> 7.7)
     - GoogleUtilities/Logger (~> 7.7)
-    - nanopb (~> 2.30908.0)
+    - nanopb (< 2.30910.0, >= 2.30908.0)
+  - FirebaseCoreInternal (9.4.0):
+    - "GoogleUtilities/NSData+zlib (~> 7.7)"
   - Flutter (1.0.0)
-  - GoogleDataTransport (9.1.2):
-    - GoogleUtilities/Environment (~> 7.2)
-    - nanopb (~> 2.30908.0)
+  - GoogleDataTransport (9.2.0):
+    - GoogleUtilities/Environment (~> 7.7)
+    - nanopb (< 2.30910.0, >= 2.30908.0)
     - PromisesObjC (< 3.0, >= 1.2)
   - GoogleUtilities/Environment (7.7.0):
     - PromisesObjC (< 3.0, >= 1.2)
   - GoogleUtilities/Logger (7.7.0):
     - GoogleUtilities/Environment
+  - "GoogleUtilities/NSData+zlib (7.7.0)"
   - MTBBarcodeScanner (5.0.11)
-  - nanopb (2.30908.0):
-    - nanopb/decode (= 2.30908.0)
-    - nanopb/encode (= 2.30908.0)
-  - nanopb/decode (2.30908.0)
-  - nanopb/encode (2.30908.0)
-  - "permission_handler (5.1.0+2)":
+  - nanopb (2.30909.0):
+    - nanopb/decode (= 2.30909.0)
+    - nanopb/encode (= 2.30909.0)
+  - nanopb/decode (2.30909.0)
+  - nanopb/encode (2.30909.0)
+  - permission_handler_apple (9.0.4):
     - Flutter
-  - PromisesObjC (2.1.0)
+  - PromisesObjC (2.1.1)
   - square_reader_sdk (3.0.0):
     - Flutter
+  - SwiftProtobuf (1.19.1)
 
 DEPENDENCIES:
-  - barcode_scan (from `.symlinks/plugins/barcode_scan/ios`)
+  - barcode_scan2 (from `.symlinks/plugins/barcode_scan2/ios`)
   - firebase_core (from `.symlinks/plugins/firebase_core/ios`)
   - Flutter (from `Flutter`)
-  - permission_handler (from `.symlinks/plugins/permission_handler/ios`)
+  - permission_handler_apple (from `.symlinks/plugins/permission_handler_apple/ios`)
   - square_reader_sdk (from `.symlinks/plugins/square_reader_sdk/ios`)
 
 SPEC REPOS:
@@ -49,39 +55,43 @@ SPEC REPOS:
     - Firebase
     - FirebaseCore
     - FirebaseCoreDiagnostics
+    - FirebaseCoreInternal
     - GoogleDataTransport
     - GoogleUtilities
     - MTBBarcodeScanner
     - nanopb
     - PromisesObjC
+    - SwiftProtobuf
 
 EXTERNAL SOURCES:
-  barcode_scan:
-    :path: ".symlinks/plugins/barcode_scan/ios"
+  barcode_scan2:
+    :path: ".symlinks/plugins/barcode_scan2/ios"
   firebase_core:
     :path: ".symlinks/plugins/firebase_core/ios"
   Flutter:
     :path: Flutter
-  permission_handler:
-    :path: ".symlinks/plugins/permission_handler/ios"
+  permission_handler_apple:
+    :path: ".symlinks/plugins/permission_handler_apple/ios"
   square_reader_sdk:
     :path: ".symlinks/plugins/square_reader_sdk/ios"
 
 SPEC CHECKSUMS:
-  barcode_scan: 33f586d02270046fc6559135038b34b5754eaa4f
-  Firebase: 5f8193dff4b5b7c5d5ef72ae54bb76c08e2b841d
-  firebase_core: 6ef152b7d6a361e24105e2cc56ab458f1f8367fe
-  FirebaseCore: 5743c5785c074a794d35f2fff7ecc254a91e08b1
-  FirebaseCoreDiagnostics: 92e07a649aeb66352b319d43bdd2ee3942af84cb
+  barcode_scan2: 0af2bb63c81b4565aab6cd78278e4c0fa136dbb0
+  Firebase: ef75abb1cdbc746d5a38f4e26c422c807b189b8c
+  firebase_core: e66a443ec996cb5e364dc70b4cfc1809c32cbb2e
+  FirebaseCore: c088995ece701a021a48a1348ea0174877de2a6a
+  FirebaseCoreDiagnostics: aaa87098082c4d4bdd1a9557b1186d18ca85ce8c
+  FirebaseCoreInternal: a13302b0088fbf5f38b79b6ece49c2af7d3e05d6
   Flutter: 50d75fe2f02b26cc09d224853bb45737f8b3214a
-  GoogleDataTransport: 629c20a4d363167143f30ea78320d5a7eb8bd940
+  GoogleDataTransport: 1c8145da7117bd68bbbed00cf304edb6a24de00f
   GoogleUtilities: e0913149f6b0625b553d70dae12b49fc62914fd1
   MTBBarcodeScanner: f453b33c4b7dfe545d8c6484ed744d55671788cb
-  nanopb: a0ba3315591a9ae0a16a309ee504766e90db0c96
-  permission_handler: ccb20a9fad0ee9b1314a52b70b76b473c5f8dab0
-  PromisesObjC: 99b6f43f9e1044bd87a95a60beff28c2c44ddb72
-  square_reader_sdk: c180851c81247aed31ef44b8b7d756b12232e078
+  nanopb: b552cce312b6c8484180ef47159bc0f65a1f0431
+  permission_handler_apple: 44366e37eaf29454a1e7b1b7d736c2cceaeb17ce
+  PromisesObjC: ab77feca74fa2823e7af4249b8326368e61014cb
+  square_reader_sdk: 9f71e845136d9ebc33bf9e0dfc52f6cb1891655f
+  SwiftProtobuf: 59d9ea2eb5f84b509f32d170a65f3348ae758f1e
 
-PODFILE CHECKSUM: ec61324b104374c43daa9dda8122c618e1e72f0e
+PODFILE CHECKSUM: 3ceefe9d94e435d066c1c3f69ed8e7d6a52397ff
 
-COCOAPODS: 1.11.3
+COCOAPODS: 1.11.2

--- a/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/example/ios/Runner.xcodeproj/project.pbxproj
@@ -3,18 +3,18 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 52;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
-		005B53CE282383680093224F /* SquareReaderSDK.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 005B53CD282383670093224F /* SquareReaderSDK.xcframework */; };
 		005B53D428238D590093224F /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = 005B53D228238D590093224F /* LaunchScreen.xib */; };
 		1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */ = {isa = PBXBuildFile; fileRef = 1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */; };
+		17130ABD28ACD16B007FE54B /* SquareReaderSDK.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 005B53CD282383670093224F /* SquareReaderSDK.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
+		5F42FE4CAFE54D4DF6D888F1 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9F2AFA1EB37353EA7E1732D1 /* Pods_Runner.framework */; };
 		74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74858FAE1ED2DC5600515810 /* AppDelegate.swift */; };
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
-		F49595206509B1C4954C3358 /* libPods-Runner.a in Frameworks */ = {isa = PBXBuildFile; fileRef = D7BFA22AB7DDF1583583C3A6 /* libPods-Runner.a */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -24,6 +24,7 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
+				17130ABD28ACD16B007FE54B /* SquareReaderSDK.xcframework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -38,7 +39,6 @@
 		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
 		74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Runner-Bridging-Header.h"; sourceTree = "<group>"; };
 		74858FAE1ED2DC5600515810 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
-		7A07034A14FBEF244493A4CD /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = Flutter/Release.xcconfig; sourceTree = "<group>"; };
 		9740EEB21CF90195004384FC /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Debug.xcconfig; path = Flutter/Debug.xcconfig; sourceTree = "<group>"; };
 		9740EEB31CF90195004384FC /* Generated.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Generated.xcconfig; path = Flutter/Generated.xcconfig; sourceTree = "<group>"; };
@@ -46,9 +46,10 @@
 		97C146FB1CF9000F007C117D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		97C146FD1CF9000F007C117D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		97C147021CF9000F007C117D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		B84A8F4277CD9701E270C490 /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
-		CE087EAD820AE01DB61B8024 /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
-		D7BFA22AB7DDF1583583C3A6 /* libPods-Runner.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Runner.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		9F2AFA1EB37353EA7E1732D1 /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		DF223B3C6E6952903590620E /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
+		E6381330E4714A0A93FEBB81 /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
+		FBA9A6FAAB150EDCEE33CFC4 /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -56,8 +57,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				005B53CE282383680093224F /* SquareReaderSDK.xcframework in Frameworks */,
-				F49595206509B1C4954C3358 /* libPods-Runner.a in Frameworks */,
+				5F42FE4CAFE54D4DF6D888F1 /* Pods_Runner.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -67,19 +67,11 @@
 		38F5D90BB359E269682BB160 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				CE087EAD820AE01DB61B8024 /* Pods-Runner.debug.xcconfig */,
-				7A07034A14FBEF244493A4CD /* Pods-Runner.release.xcconfig */,
-				B84A8F4277CD9701E270C490 /* Pods-Runner.profile.xcconfig */,
+				FBA9A6FAAB150EDCEE33CFC4 /* Pods-Runner.debug.xcconfig */,
+				E6381330E4714A0A93FEBB81 /* Pods-Runner.release.xcconfig */,
+				DF223B3C6E6952903590620E /* Pods-Runner.profile.xcconfig */,
 			);
 			path = Pods;
-			sourceTree = "<group>";
-		};
-		70CF53F550EBE83F5463A252 /* Frameworks */ = {
-			isa = PBXGroup;
-			children = (
-				D7BFA22AB7DDF1583583C3A6 /* libPods-Runner.a */,
-			);
-			name = Frameworks;
 			sourceTree = "<group>";
 		};
 		9740EEB11CF90186004384FC /* Flutter */ = {
@@ -101,7 +93,7 @@
 				97C146F01CF9000F007C117D /* Runner */,
 				97C146EF1CF9000F007C117D /* Products */,
 				38F5D90BB359E269682BB160 /* Pods */,
-				70CF53F550EBE83F5463A252 /* Frameworks */,
+				B1C8473416F062D8E91D6A67 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -128,6 +120,14 @@
 			path = Runner;
 			sourceTree = "<group>";
 		};
+		B1C8473416F062D8E91D6A67 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				9F2AFA1EB37353EA7E1732D1 /* Pods_Runner.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -135,13 +135,15 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 97C147051CF9000F007C117D /* Build configuration list for PBXNativeTarget "Runner" */;
 			buildPhases = (
-				ADA99C57C9DF6F1F13424EF4 /* [CP] Check Pods Manifest.lock */,
+				90342CCEE2EE75FC4F40EB89 /* [CP] Check Pods Manifest.lock */,
 				9740EEB61CF901F6004384FC /* Run Script */,
 				97C146EA1CF9000F007C117D /* Sources */,
 				97C146EB1CF9000F007C117D /* Frameworks */,
 				97C146EC1CF9000F007C117D /* Resources */,
 				9705A1C41CF9048500538489 /* Embed Frameworks */,
 				3B06AD1E1E4923F5004D2608 /* Thin Binary */,
+				17130ABE28ACDC4A007FE54B /* Square setup script */,
+				324E410A8DA310037B0B821B /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -200,6 +202,42 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		17130ABE28ACDC4A007FE54B /* Square setup script */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Square setup script";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "FRAMEWORKS=\"${BUILT_PRODUCTS_DIR}/${FRAMEWORKS_FOLDER_PATH}\"\n\"${FRAMEWORKS}/SquareReaderSDK.framework/setup\"\n\n";
+		};
+		324E410A8DA310037B0B821B /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
 		3B06AD1E1E4923F5004D2608 /* Thin Binary */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -214,21 +252,7 @@
 			shellPath = /bin/sh;
 			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" embed_and_thin";
 		};
-		9740EEB61CF901F6004384FC /* Run Script */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Run Script";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" build";
-		};
-		ADA99C57C9DF6F1F13424EF4 /* [CP] Check Pods Manifest.lock */ = {
+		90342CCEE2EE75FC4F40EB89 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -249,6 +273,20 @@
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
+		};
+		9740EEB61CF901F6004384FC /* Run Script */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Run Script";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" build\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/example/ios/Runner/Info.plist
+++ b/example/ios/Runner/Info.plist
@@ -55,5 +55,7 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
+	<key>CADisableMinimumFrameDurationOnPhone</key>
+	<true/>
 </dict>
 </plist>

--- a/example/lib/screens/authorize_screen.dart
+++ b/example/lib/screens/authorize_screen.dart
@@ -76,7 +76,7 @@ class _AuthorizeScreenState extends State<AuthorizeScreen> {
     }
   }
 
-  Future scan() async {
+  Future<void> scan() async {
     try {
       var result = await BarcodeScanner.scan();
       authorizeQRCode(result.rawContent);
@@ -91,11 +91,11 @@ class _AuthorizeScreenState extends State<AuthorizeScreen> {
     }
   }
 
-  void scanQRCode() async {
+  void scanQRCode() {
     scan();
   }
 
-  void manuallyEnterCode() async {
+  void manuallyEnterCode() {
     Navigator.pushNamed(context, '/authorize/manual');
   }
 
@@ -135,8 +135,8 @@ class _Description extends StatelessWidget {
 }
 
 class _Buttons extends StatelessWidget {
-  final Function manuallyEnterCode;
-  final Function scanQRCode;
+  final VoidCallback manuallyEnterCode;
+  final VoidCallback scanQRCode;
 
   _Buttons({
     required this.scanQRCode,
@@ -148,9 +148,9 @@ class _Buttons extends StatelessWidget {
           child: SQButtonContainer(buttons: [
         SQRaisedButton(
           text: 'Scan QR Code',
-          onPressed: scanQRCode as void Function(),
+          onPressed: scanQRCode,
         ),
         SQOutlineButton(
-            text: 'Manually Enter Code', onPressed: manuallyEnterCode as void Function()),
+            text: 'Manually Enter Code', onPressed: manuallyEnterCode),
       ]));
 }

--- a/example/lib/screens/authorize_screen.dart
+++ b/example/lib/screens/authorize_screen.dart
@@ -14,11 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import 'package:barcode_scan/barcode_scan.dart';
+import 'package:barcode_scan2/barcode_scan2.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:square_reader_sdk/reader_sdk.dart';
 import 'package:square_reader_sdk/models.dart';
+import 'package:square_reader_sdk/reader_sdk.dart';
 
 import 'widgets/buttons.dart';
 import 'widgets/dialog_modal.dart';
@@ -78,10 +78,10 @@ class _AuthorizeScreenState extends State<AuthorizeScreen> {
 
   Future scan() async {
     try {
-      var barcode = await BarcodeScanner.scan();
-      authorizeQRCode(barcode);
+      var result = await BarcodeScanner.scan();
+      authorizeQRCode(result.rawContent);
     } on PlatformException catch (e) {
-      if (e.code == BarcodeScanner.CameraAccessDenied) {
+      if (e.code == BarcodeScanner.cameraAccessDenied) {
         displayErrorModal(context, 'Camera Access was not granted');
       } else {
         displayErrorModal(context, e.toString());

--- a/example/lib/screens/checkout_screen.dart
+++ b/example/lib/screens/checkout_screen.dart
@@ -66,7 +66,7 @@ class _CheckoutScreenState extends State<CheckoutScreen> {
                 ),
               ),
               actions: <Widget>[
-                FlatButton(
+                TextButton(
                   child: Text('OK'),
                   onPressed: () {
                     Navigator.of(context).pop();
@@ -196,7 +196,7 @@ class _CheckoutScreenState extends State<CheckoutScreen> {
                       Container(
                         alignment: Alignment.centerRight,
                         child: SQSettingButton(
-                            onPressed: onSettings as void Function()),
+                            onPressed: onSettings),
                       ),
                       SquareLogo(),
                       _Description(),
@@ -256,14 +256,14 @@ class _SettingsModalPopup extends StatelessWidget {
   Widget build(BuildContext context) => CupertinoActionSheet(
         title: Text('Location: $locationName'),
         actions: [
-          FlatButton(
+          TextButton(
             child: Text(
               'Reader Settings',
               style: TextStyle(color: Colors.blue),
             ),
             onPressed: onReaderSDKSettings as void Function()?,
           ),
-          FlatButton(
+          TextButton(
             child: Text(
               'Deauthorize',
               style: TextStyle(color: Colors.red),
@@ -271,7 +271,7 @@ class _SettingsModalPopup extends StatelessWidget {
             onPressed: onDeauthorize,
           ),
         ],
-        cancelButton: FlatButton(
+        cancelButton: TextButton(
           child: Text(
             'Cancel',
             style: TextStyle(color: Colors.blue),

--- a/example/lib/screens/checkout_screen.dart
+++ b/example/lib/screens/checkout_screen.dart
@@ -173,7 +173,7 @@ class _CheckoutScreenState extends State<CheckoutScreen> {
       context: context,
       builder: (var context) => _SettingsModalPopup(
         locationName: location.name,
-        onReaderSDKSettings: () => onReaderSDKSettings,
+        onReaderSDKSettings: onReaderSDKSettings,
         onDeauthorize: () => confirmOnDeauthorize(
             context: context,
             onPressed: () {
@@ -243,7 +243,7 @@ class _Buttons extends StatelessWidget {
 
 class _SettingsModalPopup extends StatelessWidget {
   final String locationName;
-  final Function onReaderSDKSettings;
+  final Function()? onReaderSDKSettings;
   final VoidCallback? onDeauthorize;
 
   _SettingsModalPopup({
@@ -261,7 +261,7 @@ class _SettingsModalPopup extends StatelessWidget {
               'Reader Settings',
               style: TextStyle(color: Colors.blue),
             ),
-            onPressed: onReaderSDKSettings as void Function()?,
+            onPressed: onReaderSDKSettings,
           ),
           TextButton(
             child: Text(

--- a/example/lib/screens/checkout_screen.dart
+++ b/example/lib/screens/checkout_screen.dart
@@ -202,7 +202,6 @@ class _CheckoutScreenState extends State<CheckoutScreen> {
                       _Description(),
                       _Buttons(
                         onCharge: onCharge,
-                        onSettings: onSettings,
                       ),
                     ]),
               ),
@@ -222,12 +221,10 @@ class _Description extends StatelessWidget {
 }
 
 class _Buttons extends StatelessWidget {
-  final Function onCharge;
-  final Function onSettings;
+  final VoidCallback onCharge;
 
   _Buttons({
     required this.onCharge,
-    required this.onSettings,
   });
 
   @override
@@ -235,7 +232,7 @@ class _Buttons extends StatelessWidget {
         child: SQButtonContainer(buttons: [
           SQRaisedButton(
             text: 'Charge \$1.00',
-            onPressed: onCharge as void Function(),
+            onPressed: onCharge,
           ),
         ]),
       );

--- a/example/lib/screens/manual_authorize_screen.dart
+++ b/example/lib/screens/manual_authorize_screen.dart
@@ -15,8 +15,8 @@ limitations under the License.
 */
 
 import 'package:flutter/material.dart';
-import 'package:square_reader_sdk/reader_sdk.dart';
 import 'package:square_reader_sdk/models.dart';
+import 'package:square_reader_sdk/reader_sdk.dart';
 
 import 'widgets/buttons.dart';
 import 'widgets/dialog_modal.dart';

--- a/example/lib/screens/splash_screen.dart
+++ b/example/lib/screens/splash_screen.dart
@@ -100,7 +100,7 @@ class _ButtonContainerState extends State<_ButtonContainer> {
   bool _hasMicrophoneAccess = false;
   String _microphoneButtonText = 'Enable Microphone Access';
 
-  bool _hasBluetoothAccess = _requireBluetoothPermission;
+  bool _hasBluetoothAccess = !_requireBluetoothPermission;
   String _bluetoothButtonText = 'Enable Bluetooth Access';
 
   // @override

--- a/example/lib/screens/splash_screen.dart
+++ b/example/lib/screens/splash_screen.dart
@@ -162,7 +162,12 @@ class _ButtonContainerState extends State<_ButtonContainer> {
     updateBluetoothStatus(permissionsStatus.sublist(2));
 
     if (_hasLocationAccess && _hasMicrophoneAccess && _hasBluetoothAccess) {
-      Navigator.popAndPushNamed(context, '/authorize');
+      Navigator.popAndPushNamed(
+        context,
+        await ReaderSdk.isAuthorized
+            ? '/checkout'
+            : '/authorize'
+      );
     }
   }
 

--- a/example/lib/screens/widgets/animated_square_logo.dart
+++ b/example/lib/screens/widgets/animated_square_logo.dart
@@ -14,7 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import 'package:flutter/animation.dart';
 import 'package:flutter/material.dart';
 
 class _LogoAnimated extends AnimatedWidget {
@@ -28,7 +27,7 @@ class _LogoAnimated extends AnimatedWidget {
       : super(key: key, listenable: animation);
 
   Widget build(BuildContext context) {
-    final Animation<double> animation = listenable as Animation<double>;
+    final animation = listenable as Animation<double>;
     return Container(
       alignment: _alignmentTween.evaluate(animation),
       margin: EdgeInsets.symmetric(vertical: 100.0),

--- a/example/lib/screens/widgets/buttons.dart
+++ b/example/lib/screens/widgets/buttons.dart
@@ -125,11 +125,13 @@ class SQRaisedButton extends StatelessWidget {
   final void Function() onPressed;
 
   @override
-  Widget build(BuildContext context) => RaisedButton(
+  Widget build(BuildContext context) => ElevatedButton(
         child: Text(text),
-        textColor: Colors.white,
-        color: Color.fromRGBO(57, 114, 178, 1.0),
-        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8.0)),
+        style: ElevatedButton.styleFrom(
+          primary: Color.fromRGBO(57, 114, 178, 1.0),
+          onPrimary: Colors.white,
+          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8.0)),
+        ),
         onPressed: onPressed,
       );
 }

--- a/example/lib/screens/widgets/buttons.dart
+++ b/example/lib/screens/widgets/buttons.dart
@@ -90,7 +90,7 @@ class SQSettingButton extends StatelessWidget {
   });
 
   /// a callback that is fired when the button is pressed
-  final void Function()? onPressed;
+  final VoidCallback? onPressed;
 
   @override
   Widget build(BuildContext context) => OutlinedButton(

--- a/example/lib/screens/widgets/dialog_modal.dart
+++ b/example/lib/screens/widgets/dialog_modal.dart
@@ -40,7 +40,7 @@ Future<Null> displayErrorModal(BuildContext context, String message) =>
                 ),
               ),
               actions: <Widget>[
-                FlatButton(
+                TextButton(
                   child: Text('OK'),
                   onPressed: () {
                     Navigator.of(context).pop();

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -17,9 +17,9 @@ dependencies:
     sdk: flutter
 
   permission_handler: ^9.2.0
-  barcode_scan: ^2.0.2
+  barcode_scan2: ^4.2.1
   intl: ^0.17.0
-  firebase_core: ^1.16.0
+  firebase_core: ^1.20.1
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.

--- a/ios/square_reader_sdk.podspec
+++ b/ios/square_reader_sdk.podspec
@@ -18,6 +18,7 @@ iOS part of a flutter plugin for Square Reader SDK.
   s.frameworks       = 'SquareReaderSDK'
   s.xcconfig = {
     'OTHER_LDFLAGS' => '-framework SquareReaderSDK',
+    'ENABLE_BITCODE' => 'NO',
     'FRAMEWORK_SEARCH_PATHS[sdk=iphoneos*]' => '$(inherited) $(PROJECT_DIR)/../SquareReaderSDK.xcframework/ios-arm64',
     'FRAMEWORK_SEARCH_PATHS[sdk=iphonesimulator*]' => '$(inherited) $(PROJECT_DIR)/../SquareReaderSDK.xcframework/ios-arm64_x86_64-simulator'
   }

--- a/ios/square_reader_sdk.podspec
+++ b/ios/square_reader_sdk.podspec
@@ -16,10 +16,18 @@ iOS part of a flutter plugin for Square Reader SDK.
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
   s.frameworks       = 'SquareReaderSDK'
-  s.xcconfig         = {
-      'FRAMEWORK_SEARCH_PATHS[sdk=iphoneos*]' => '$(PROJECT_DIR)/../SquareReaderSDK.xcframework/ios-arm64',
-      'FRAMEWORK_SEARCH_PATHS[sdk=iphonesimulator*]' => '$(PROJECT_DIR)/../SquareReaderSDK.xcframework/ios-x86_64-simulator'
-    }
+  s.xcconfig = {
+    'OTHER_LDFLAGS' => '-framework SquareReaderSDK',
+    'FRAMEWORK_SEARCH_PATHS[sdk=iphoneos*]' => '$(inherited) $(PROJECT_DIR)/../SquareReaderSDK.xcframework/ios-arm64',
+    'FRAMEWORK_SEARCH_PATHS[sdk=iphonesimulator*]' => '$(inherited) $(PROJECT_DIR)/../SquareReaderSDK.xcframework/ios-arm64_x86_64-simulator'
+  }
+  s.vendored_frameworks = 'SquareReaderSDK.xcframework'
+    # Flutter.framework does not contain a i386 slice.
+  s.pod_target_xcconfig = {
+    'DEFINES_MODULE' => 'YES',
+    'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386',
+  }
+  s.swift_version = '5.0'
 
   s.ios.deployment_target = '11.1'
 end

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,8 +4,8 @@ version: 3.0.0
 homepage: https://github.com/square/reader-sdk-flutter-plugin
 
 environment:
-  sdk: '>=2.17.0 <3.0.0'
-  flutter: ">=3.0.0"
+  sdk: '>=2.14.0 <3.0.0'
+  flutter: ">=2.0.0"
 
 dependencies:
   flutter:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,8 +4,8 @@ version: 3.0.0
 homepage: https://github.com/square/reader-sdk-flutter-plugin
 
 environment:
-  sdk: '>=2.14.0 <3.0.0'
-  flutter: ">=1.10.0"
+  sdk: '>=2.17.0 <3.0.0'
+  flutter: ">=3.0.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
## Summary

- migrate example project to support Flutter 3
- fix issues in example project
- add support to use target SDK 31 and higher
- fix iOS plugin usage with other native libraries
- fix iOS plugin for simulators

**IMPORTANT** Requires 4.x version publish to pub.dev since it has breaking changes related to Android configuration (see Migration guide)

## Related issues

Fix #92, Fix #80, Fix #91 

## Changelog

- migrate example project to support Flutter 3
- fix issues in example project
- add support to use target SDK 31 (Android 12) and higher (#80)
- fix iOS plugin usage with other native libraries (#92)
- fix iOS plugin for simulators (#92)

## Test Plan

Manually test the quick start example works with Flutter 3 on Android 12 and 13 and with iOS simulator