### PR TITLE
Adding try/catch to make initialization bulletproof.

### DIFF
--- a/android/src/main/java/com/squareup/sdk/reader/flutter/SquareReaderSdkFlutterPlugin.java
+++ b/android/src/main/java/com/squareup/sdk/reader/flutter/SquareReaderSdkFlutterPlugin.java
@@ -157,7 +157,11 @@ public class SquareReaderSdkFlutterPlugin implements MethodCallHandler, FlutterP
       return;
     }
 
-    ReaderSdk.initialize(currentActivity.getApplication());
-    sdkInitialized = true;
+    try {
+      ReaderSdk.initialize(currentActivity.getApplication());
+      sdkInitialized = true; 
+    } catch (IllegalStateException e) {
+      // do nothing; something already initialized the SDK outside the plugin.
+    }
   }
 }


### PR DESCRIPTION
This helps is if a developer initializes the SDK early, themselves, outside of the plugin.  And we have a report from Weaver that this happens inside of Android's Activity.onCreate if recovering from a state that includes an instance of ResultFragment.
