### PR TITLE
Adding publishing action which allows automated publishing.

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,14 @@
+name: Publish to pub.dev
+
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+*'
+
+jobs:
+  publish:
+    permissions:
+      id-token: write # Required for authentication using OIDC
+    uses: dart-lang/setup-dart/.github/workflows/publish.yml@v1
+    # with:
+    #   working-directory: path/to/package/within/repository


### PR DESCRIPTION


## Summary

Adding a publishing workflow following the instructions in pub.dev. This should allow us to publish by pushing a tag with an agreed upon convention.

## Related issues

N/A

## Changelog

Added publish.yml. 

## Test Plan

Tested the actions described in the dart-lang workflow (https://github.com/dart-lang/setup-dart/blob/main/.github/workflows/publish.yml) locally in my computer.