### PR TITLE
Mark Reader SDK Flutter plugin as retired

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+# ⚠️ RETIRED — Reader SDK is no longer supported
+
+> [!CAUTION]
+> **Reader SDK has been retired and can no longer be used to accept payments.**
+> Reader SDK was [deprecated in January 2025](https://developer.squareup.com/docs/changelog/mobile-logs/2025-01-23) and retired on **December 31, 2025**. This plugin no longer functions, and this repository is no longer maintained.
+>
+> Migrate to the [Mobile Payments SDK](https://developer.squareup.com/docs/mobile-payments-sdk), Square's supported solution for in-person payments, which has an official [Flutter plugin](https://github.com/square/mobile-payments-sdk-flutter). See the [migration guide](https://developer.squareup.com/docs/mobile-payments-sdk/migrate) to get started.
+
 # Flutter plugin for Reader SDK
 
 [![build](https://github.com/square/reader-sdk-flutter-plugin/actions/workflows/build.yml/badge.svg)](https://github.com/square/reader-sdk-flutter-plugin/actions/workflows/build.yml)


### PR DESCRIPTION
## Description

Reader SDK 1 was [deprecated in January 2025](https://developer.squareup.com/docs/changelog/mobile-logs/2025-01-23) and retired on December 31, 2025 — it can no longer be used to accept payments.

This adds a prominent retirement banner at the top of the README:
- States the plugin no longer functions and the repo is no longer maintained
- Points developers to the [Mobile Payments SDK](https://developer.squareup.com/docs/mobile-payments-sdk) and its official [Flutter plugin](https://github.com/square/mobile-payments-sdk-flutter)
- Links the [migration guide](https://developer.squareup.com/docs/mobile-payments-sdk/migrate)

The rest of the README is intentionally left in place for developers still untangling existing integrations. The repo will be archived after this merges.